### PR TITLE
Update provider.go

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -84,10 +84,10 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (any, diag.D
 	switch region {
 	case "eu":
 		client.SetHost("https://cloudinfra-gw.portal.checkpoint.com")
-		client.SetEndpoint("/app/i2/graphql/V1")
+		client.SetEndpoint("/app/waf/graphql/V1")
 	case "us":
 		client.SetHost("https://cloudinfra-gw-us.portal.checkpoint.com")
-		client.SetEndpoint("/app/i2/graphql/V1")
+		client.SetEndpoint("/app/waf/graphql/V1")
 	case "dev":
 		client.SetHost("https://dev-cloudinfra-gw.kube1.iaas.checkpoint.com")
 		client.SetEndpoint("/app/infinity2gem/graphql/V1")


### PR DESCRIPTION
When you call API with terraform like in WAF docs :
`data "http" "profiles" {
  depends_on = [data.http.policy_token]
  url    = "https://cloudinfra-gw.portal.checkpoint.com/app/waf/graphql/V1"
  method = "POST"
  request_headers = {
    "authorization" = "Bearer ${local.policy_token}"
    "content-type"  = "application/json"
  }
  request_body = <<EOT
    { 
        "query": "query getProfiles($matchSearch: String) { getProfiles(matchSearch: $matchSearch) { id name profileType }}",
        "variables": { "matchSearch": "${local.profile_name}" } 
    }
EOT
}`
We have 401 unauthorized