### PR TITLE
fix: pin GitHub Actions to full SHA (CLOUDEVOPS-4942)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,23 +21,23 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: 1.24
       -
         name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         with:
           # These secrets will need to be configured for the repository:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
           args: release --clean

--- a/.github/workflows/sourceguard.yml
+++ b/.github/workflows/sourceguard.yml
@@ -11,7 +11,7 @@ jobs:
       image: sourceguard/sourceguard-cli
     steps:
       - name: Scan
-        uses: CheckPointSW/sourceguard-action@main
+        uses: CheckPointSW/sourceguard-action@ddeadaa391a6defb21ef4228b91956b062c27862 # main
         with:
           SG_CLIENT_ID: ${{ secrets.SG_CLIENT_ID }}
           SG_SECRET_KEY: ${{ secrets.SG_SECRET_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: "1.24"
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Get dependencies
         run: |
@@ -38,14 +38,14 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: "1.24"
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2
         with:
           terraform_version: 1.10.0
           terraform_wrapper: false
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - run: go generate ./...
       - name: git diff
         run: |
@@ -71,18 +71,18 @@ jobs:
           - "1.1.*"
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: "1.24"
         id: go
 
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Get dependencies
         run: |
@@ -150,18 +150,18 @@ jobs:
           - "1.1.*"
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: "1.24"
         id: go
 
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Get dependencies
         run: |
@@ -232,18 +232,18 @@ jobs:
   #          - '1.1.*'
   #    steps:
   #    - name: Set up Go
-  #      uses: actions/setup-go@v3
+  #      uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
   #      with:
   #        go-version: '1.24'
   #      id: go
   #
-  #    - uses: hashicorp/setup-terraform@v2
+  #    - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2
   #      with:
   #        terraform_version: ${{ matrix.terraform }}
   #        terraform_wrapper: false
   #
   #    - name: Check out code into the Go module directory
-  #      uses: actions/checkout@v3
+  #      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
   #
   #    - name: Get dependencies
   #      run: |
@@ -314,18 +314,18 @@ jobs:
           - "1.1.*"
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: "1.24"
         id: go
 
-      - uses: hashicorp/setup-terraform@v2
+      - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Get dependencies
         run: |


### PR DESCRIPTION
## External Actions (pinned to SHA)

**CheckPointSW**

- `CheckPointSW/sourceguard-action@main` → `ddeadaa` · [verify](https://github.com/CheckPointSW/sourceguard-action/commit/ddeadaa391a6defb21ef4228b91956b062c27862)

**actions**

- `actions/checkout@v3` → `f43a0e5` · [verify](https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744)
- `actions/setup-go@v3` → `be3c94b` · [verify](https://github.com/actions/setup-go/commit/be3c94b385c4f180051c996d336f57a34c397495)

**crazy-max**

- `crazy-max/ghaction-import-gpg@v6` → `e89d409` · [verify](https://github.com/crazy-max/ghaction-import-gpg/commit/e89d40939c28e39f97cf32126055eeae86ba74ec)

**goreleaser**

- `goreleaser/goreleaser-action@v6` → `e435ccd` · [verify](https://github.com/goreleaser/goreleaser-action/commit/e435ccd777264be153ace6237001ef4d979d3a7a)

**hashicorp**

- `hashicorp/setup-terraform@v2` → `633666f` · [verify](https://github.com/hashicorp/setup-terraform/commit/633666f66e0061ca3b725c73b2ec20cd13a8fdd1)